### PR TITLE
Update jupyter-dockerfile

### DIFF
--- a/docker/jupyter-dockerfile
+++ b/docker/jupyter-dockerfile
@@ -1,5 +1,5 @@
 #FROM nvidia/cuda:cudnn
- FROM ubuntu
+ FROM nvidia/cuda
 MAINTAINER Tobias Gruber 
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/docker/jupyter-dockerfile
+++ b/docker/jupyter-dockerfile
@@ -1,5 +1,5 @@
-FROM nvidia/cuda:cudnn
-
+#FROM nvidia/cuda:cudnn
+ FROM ubuntu
 MAINTAINER Tobias Gruber 
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Problem with "FROM nvidia/cuda:cudnn"
--> manifest cannot be found. 
I tried to use ony "nvidia/cuda" as can be seen from 
https://hub.docker.com/r/nvidia/cuda/
docker pull nvidia/cuda